### PR TITLE
Intermediate Certificate Param

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ push.websiteJSON = function (name, pushId, allowedDomains, urlFormattingString, 
     };
 };
 
-push.generatePackage = function(websiteJSON, iconsDir, certData, pKeyData) {
+push.generatePackage = function(websiteJSON, iconsDir, certData, pKeyData, intermediate) {
     if (typeof websiteJSON !== 'object' && !('websitePushID' in websiteJSON)) {
         throw new Error("websiteJSON should be generated using websiteJSON() method");
     }
@@ -50,9 +50,14 @@ push.generatePackage = function(websiteJSON, iconsDir, certData, pKeyData) {
     if (typeof pKeyData == 'string') {
         pKeyData = new Buffer(pKeyData);
     }
-    var pkcs7sig = pkcs7.sign(certData, pKeyData, manifestContent),
+    if(intermediate && typeof intermediate == 'string') {
+        intermediate = new Buffer(intermediate)
+    }
+    var pkcs7sig = intermediate ? pkcs7.sign(certData, pKeyData, manifestContent, intermediate) : pkcs7.sign(certData, pKeyData, manifestContent),
         content = PKCS7_CONTENT_REGEX.exec(pkcs7sig.toString());
+
     content = new Buffer(content[1], 'base64');
+    console.log(content.toString("base64"))
     pkg.addFile("signature", content);
     return pkg.toBuffer();
 };

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ push.generatePackage = function(websiteJSON, iconsDir, certData, pKeyData, inter
         content = PKCS7_CONTENT_REGEX.exec(pkcs7sig.toString());
 
     content = new Buffer(content[1], 'base64');
-    console.log(content.toString("base64"))
     pkg.addFile("signature", content);
+
     return pkg.toBuffer();
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safari-push-notifications",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Helper methods for generating resources required by Apple's Safari Push Notifications (http://apple.co/1P39vbY)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Apple's WWDR certificate recently expired. : https://developer.apple.com/support/certificates/expiration/
Apple has hosted a new certificate here : https://www.apple.com/certificateauthority/

As per Apple's recommendation
> If you were using the openssl_pkcs7_sign function to sign your push package with only your web push certificate, you should pass the path to the renewed intermediate for the extra certificates parameter.

However, the module didn't have the provision to supply this extra param. This PR implements it and allows for optionally passing the required extra param.

~~~javascript
var cert = fs.readFileSync('cert.pem')
var key = fs.readFileSync('key.pem')
var intermediate = fs.readFileSync('AppleWWDRCA.pem')

var zipBuffer = pushLib.generatePackage(
    websiteJson, // The object from before / your own website.json object 
    iconsPath, // Folder containing the iconset 
    cert, // Certificate 
    key, // Private Key 
    intermediate //WWDR CA
)
~~~

To convert Apple's `cer` to `pem`:
~~~bash
openssl x509 -inform der -in AppleWWDRCA.cer -out AppleWWDRCA.pem
~~~

The changes have been tested on our production servers and confirmed working. Apple sometimes throws the 'Extracting push notification package failed' error, but it doesn't seem to be the module's issue as retrying works. 