### PR TITLE
Use JSZip, add ability to specify icons manually, return stream instead of buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,5 +75,5 @@ push.generatePackage = function(websiteJSON, iconsDir, certData, pKeyData, inter
     content = new Buffer(content[1], 'base64');
     zip.file('signature', content);
 
-    zip.generateNodeStream({ type: 'nodebuffer', streamFiles: true });
+    return zip.generateNodeStream({ type: 'nodebuffer', streamFiles: true });
 };

--- a/index.js
+++ b/index.js
@@ -59,7 +59,8 @@ push.generatePackage = function(websiteJSON, iconsDir, certData, pKeyData, inter
     icons.file();
 
     // manifest.json
-    zip.file('manifest.json', JSON.stringify(manifest));
+    var manifestContent = new Buffer(JSON.stringify(manifest));
+    zip.file('manifest.json', manifestContent);
 
     // signature
     if (typeof certData == 'string') {

--- a/index.js
+++ b/index.js
@@ -78,7 +78,5 @@ push.generatePackage = function(websiteJSON, iconsDir, certData, pKeyData, inter
     content = new Buffer(content[1], 'base64');
     zip.file('signature', content);
 
-    zip.generateAsync({ type: 'nodebuffer '}).then(function(buffer) {
-        callback(buffer);
-    });
+    zip.generateNodeStream({ type: 'nodebuffer', streamFiles: true });
 };

--- a/index.js
+++ b/index.js
@@ -75,5 +75,5 @@ push.generatePackage = function(websiteJSON, iconsDir, certData, pKeyData, inter
     content = new Buffer(content[1], 'base64');
     zip.file('signature', content);
 
-    return zip.generateNodeStream({ type: 'nodebuffer', streamFiles: true });
+    return zip.generateNodeStream({ type: 'nodebuffer', streamFiles: false });
 };

--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
-var utils = require("./utils"),
-    pkcs7 = require("bindings")("pkcs7"),
-    AdmZip = require('adm-zip');
+var fs = require('fs'),
+    path = require('path'),
+    utils = require("./utils"),
+    pkcs7 = require('bindings')('pkcs7'),
+    JSZip = require('jszip');
 
 var push = module.exports = {},
     PKCS7_CONTENT_REGEX = /Content-Disposition:[^\n]+\s*?([A-Za-z0-9+=/\r\n]+)\s*?-----/;
 
-push.websiteJSON = function (name, pushId, allowedDomains, urlFormattingString, authToken, webServiceURL) {
+push.websiteJSON = function(name, pushId, allowedDomains, urlFormattingString, authToken, webServiceURL) {
     return {
         "websiteName": name,
         "websitePushID": pushId,
@@ -16,32 +18,48 @@ push.websiteJSON = function (name, pushId, allowedDomains, urlFormattingString, 
     };
 };
 
-push.generatePackage = function(websiteJSON, iconsDir, certData, pKeyData, intermediate) {
-    if (typeof websiteJSON !== 'object' && !('websitePushID' in websiteJSON)) {
-        throw new Error("websiteJSON should be generated using websiteJSON() method");
+push.generatePackage = function(websiteJSON, iconsDir, certData, pKeyData, intermediate, callback) {
+    if (typeof callback == 'undefined') {
+        throw new Error('this function needs an asynchronous callback')
     }
-    var pkg = new AdmZip(),
+    if (typeof websiteJSON !== 'object' && !('websitePushID' in websiteJSON)) {
+        throw new Error('websiteJSON should be generated using websiteJSON() method');
+    }
+    var zip = new JSZip(),
         manifest = {};
 
     // Replace addFile method, to calculate the sha1 on every file
-    var _addFile = pkg.addFile;
-    pkg.addFile = function (entryName, content/** Other params omitted */) {
-        if (entryName.indexOf(".DS_Store") != -1) {
-            return;
-        }
-        manifest[entryName] = utils.sha1(content);
-        _addFile.apply(pkg, Array.prototype.splice.call(arguments, 0));
+    var _addFile = zip.file;
+    zip.file = function(name, data, o) {
+        manifest[name] = utils.sha1(data);
+        _addFile.apply(zip, Array.prototype.splice.call(arguments, 0));
     };
 
     // website.json
-    pkg.addFile("website.json", new Buffer(JSON.stringify(websiteJSON)));
+    zip.file('website.json', JSON.stringify(websiteJSON));
 
     // icon.iconset
-    pkg.addLocalFolder(iconsDir, "icon.iconset");
+    var icons = zip.folder('icon.iconset');
+    if (typeof iconsDir == 'string') {
+        // expect directory name
+        fs.readdirSync(iconsDir).forEach(function (name) {
+            var filePath = path.join(iconsDir, name);
+            if (fs.statSync(filePath).isFile()) {
+                icons.file(name, fs.readFileSync(filePath));
+            }
+        });
+    } else if (typeof iconsDir == 'object') {
+        // expect object containing file buffers
+        Object.keys(iconsDir).forEach(function(name, i) {
+            icons.file(name, iconsDir[i]);
+        });
+    } else {
+        throw new Error('iconsDir not recognized');
+    }
+    icons.file();
 
     // manifest.json
-    var manifestContent = new Buffer(JSON.stringify(manifest));
-    pkg.addFile("manifest.json", manifestContent);
+    zip.file('manifest.json', JSON.stringify(manifest));
 
     // signature
     if (typeof certData == 'string') {
@@ -57,7 +75,9 @@ push.generatePackage = function(websiteJSON, iconsDir, certData, pKeyData, inter
         content = PKCS7_CONTENT_REGEX.exec(pkcs7sig.toString());
 
     content = new Buffer(content[1], 'base64');
-    pkg.addFile("signature", content);
+    zip.file('signature', content);
 
-    return pkg.toBuffer();
+    zip.generateAsync({ type: 'nodebuffer '}).then(function(buffer) {
+        callback(buffer);
+    });
 };

--- a/index.js
+++ b/index.js
@@ -18,10 +18,7 @@ push.websiteJSON = function(name, pushId, allowedDomains, urlFormattingString, a
     };
 };
 
-push.generatePackage = function(websiteJSON, iconsDir, certData, pKeyData, intermediate, callback) {
-    if (typeof callback == 'undefined') {
-        throw new Error('this function needs an asynchronous callback')
-    }
+push.generatePackage = function(websiteJSON, iconsDir, certData, pKeyData, intermediate) {
     if (typeof websiteJSON !== 'object' && !('websitePushID' in websiteJSON)) {
         throw new Error('websiteJSON should be generated using websiteJSON() method');
     }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/MySiteApp/node-safari-push-notifications",
   "dependencies": {
-    "adm-zip": "~0.4.4",
+    "jszip": "~3.0.0",
     "bindings": "~1.1.1",
     "nan": "^2.0.9"
   },


### PR DESCRIPTION
JSZip is maintained actively, while AdmZip is not. I chose to return a stream instead of a buffer, this of course is a breaking change. Returning a buffer is async with JSZip and this would be a breaking change, too.
I also added the ability to specify the icons manually, now you don't need to have a local directory with the icons and can just read them from the memory.