### PR TITLE
Fix memory leak

### DIFF
--- a/src/pkcs7.cc
+++ b/src/pkcs7.cc
@@ -90,6 +90,10 @@ NAN_METHOD(Sign) {
     sk_X509_push(sk, intermediate);
 
     p7 = PKCS7_sign(cert, pKey, sk, in, flags);
+    
+    // Free
+    X509_free(intermediate);
+    sk_X509_free(sk);
   }
 
   if (p7 == NULL) {


### PR DESCRIPTION
Hi,
Noticed a memory leak when calling the `sign` method with an intermediate certificate.
Both `intermediate` and `sk` variables are leaking.
(I'm only using the `sign` method, so not sure If another leak is still in the `verify` method)