### PR TITLE
Supported OpenSSL 1.1.0 in windows

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -11,11 +11,11 @@
             # "openssl_root" is the directory on Windows of the OpenSSL files
             ['target_arch=="x64"', {
               'variables': {
-                'openssl_root%': 'C:/OpenSSL-Win64'
+                'openssl_root%': 'C:/Program Files/OpenSSL-Win64'
               },
             }, {
               'variables': {
-                'openssl_root%': 'C:/OpenSSL-Win32'
+                'openssl_root%': 'C:/Program Files (x86)/OpenSSL-Win32'
               },
             }],
           ],
@@ -23,7 +23,7 @@
             'uint=unsigned int',
           ],
           'libraries': [
-            '-l<(openssl_root)/lib/libeay32.lib',
+            '-l<(openssl_root)/lib/libcrypto.lib',
           ],
           'include_dirs': [
             '<(openssl_root)/include'


### PR DESCRIPTION
Since version 1.1.0 OpenSSL have changed their library names from: libeay32.dll -> libcrypto.dll